### PR TITLE
Only attach slotRegistered when autoLoad is set to true

### DIFF
--- a/js/dfpslotsprovider.js
+++ b/js/dfpslotsprovider.js
@@ -55,7 +55,7 @@ export default class DFPSlotsProvider extends React.Component {
   componentDidMount() {
     DFPManager.setAdSenseAttributes(this.props.adSenseAttributes);
     DFPManager.setCollapseEmptyDivs(this.props.collapseEmptyDivs);
-    if (!this.loadAdsIfPossible()) {
+    if (this.props.autoLoad && !this.loadAdsIfPossible()) {
       DFPManager.on('slotRegistered', this.loadAdsIfPossible);
     }
   }

--- a/lib/dfpslotsprovider.js
+++ b/lib/dfpslotsprovider.js
@@ -58,7 +58,7 @@ var DFPSlotsProvider = function (_React$Component) {
     value: function componentDidMount() {
       _manager2.default.setAdSenseAttributes(this.props.adSenseAttributes);
       _manager2.default.setCollapseEmptyDivs(this.props.collapseEmptyDivs);
-      if (!this.loadAdsIfPossible()) {
+      if (this.props.autoLoad && !this.loadAdsIfPossible()) {
         _manager2.default.on('slotRegistered', this.loadAdsIfPossible);
       }
     }


### PR DESCRIPTION
Looks like in this pull request : https://github.com/jaanauati/react-dfp/pull/53/files
AutoLoad logic was lost, altho the parameter remained. This pull Request starts using the prop autoLoad once again.

My use case is to wrap the whole page into slotsProvider and then decide based on business logc wether to load ads or not through dfpManager, while maintaining the same jsx structure (with adSlots).

```javascript
class Body extends React.PureComponent {
   componentDidMount() {
     if (adsEnabled()) {
        DFPManager.load();
     }
   }
   render() {
     // Here I am not concerned at all about rendering, adSlot will be visible when component decides, it should be.
      return (<div>content <AdSlot /></div>);
   }
}

// Here the slots here will not be shown to enduser unless, the body component decides, that ads ought to be shown. Therefore I can avoid the check(isAdsVisible) here.
Layout = ({children) => (<div><div>headline<AdSlot/></div>{children}</div>)

<DFPSlotsProvider autoLoad={false}>
   <Layout>
       <Body />
    </Layout>
</DFPSlotsProvider
```