### PR TITLE
Update gpt.js url for better performance

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3,7 +3,7 @@ function doloadGPTScript(resolve, reject) {
   window.googletag.cmd = window.googletag.cmd || [];
 
   const scriptTag = document.createElement('script');
-  scriptTag.src = `${document.location.protocol}//www.googletagservices.com/tag/js/gpt.js`;
+  scriptTag.src = `${document.location.protocol}//securepubads.g.doubleclick.net/tag/js/gpt.js`;
   scriptTag.async = true;
   scriptTag.type = 'text/javascript';
   scriptTag.onerror = function scriptTagOnError(errs) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ function doloadGPTScript(resolve, reject) {
   window.googletag = window.googletag || {};
   window.googletag.cmd = window.googletag.cmd || [];
   var scriptTag = document.createElement('script');
-  scriptTag.src = "".concat(document.location.protocol, "//www.googletagservices.com/tag/js/gpt.js");
+  scriptTag.src = "".concat(document.location.protocol, "//securepubads.g.doubleclick.net/tag/js/gpt.js");
   scriptTag.async = true;
   scriptTag.type = 'text/javascript';
 


### PR DESCRIPTION
* Update `gpt.js` url per Google's instructions.

## Reference
* [What's new in Google Ad Manager](https://support.google.com/admanager/answer/179039)
   Release notes for June 3, 2019
   * The Google Publisher Tag library is now hosted at `https://securepubads.g.doubleclick.net/tag/js/gpt.js`, in addition to being hosted at `www.googletagservices.com`. While not required, we strongly recommend that you update all references to GPT on your pages to use this new domain. This change consolidates all ad serving requests to one domain. The result is an improvement in the speed of your tags and fetching ads a bit quicker.
