### PR TITLE
Remove unnecessary wrapping div in dfpSlotsProvider

### DIFF
--- a/js/dfpslotsprovider.js
+++ b/js/dfpslotsprovider.js
@@ -214,7 +214,7 @@ export default class DFPSlotsProvider extends React.Component {
   }
 
   render() {
-    const children = <div> {this.props.children} </div>;
+    const { children } = this.props;
     if (Context === null) {
       return children;
     }


### PR DESCRIPTION
This div adds an additional DOM level in all pages where dfpSlotsProvider is used.
It seems to be unnecessary, thus this PR removes its.

Since the lib is depending on React 16 (^16.4.2 at the moment), we should be fine with any type of children.