### PR TITLE
[fix] fixing enable lazy load

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -276,12 +276,12 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
         pubadsService.set(key, adSenseAttributes[key]);
       });
       if (this.lazyLoadIsEnabled()) {
-        const args = [];
         const config = this.getLazyLoadConfig();
-        if (config !== null) {
-          args.push(config);
+        if (config) {
+          pubadsService.enableLazyLoad(config);
+        } else {
+          pubadsService.enableLazyLoad();
         }
-        pubadsService.enableLazyLoad.call(args);
       }
       if (this.singleRequestIsEnabled()) {
         pubadsService.enableSingleRequest();

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -315,15 +315,13 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
       });
 
       if (_this5.lazyLoadIsEnabled()) {
-        var args = [];
-
         var config = _this5.getLazyLoadConfig();
 
-        if (config !== null) {
-          args.push(config);
+        if (config) {
+          pubadsService.enableLazyLoad(config);
+        } else {
+          pubadsService.enableLazyLoad();
         }
-
-        pubadsService.enableLazyLoad.call(args);
       }
 
       if (_this5.singleRequestIsEnabled()) {


### PR DESCRIPTION
#193 
So I believe that there were two problems:

1. googletag.PubAdsService.enableLazyLoad should receive an object but it was given an array.
2. Calling enableLazyLoad with the .call method will change the `this` reference inside the function enableLazyLoad what may be causing the bug.
