### PR TITLE
Fix a race condition when refresh is called closely to defineSlots

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -332,11 +332,13 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
     if (loadPromise === null) {
       this.load();
     } else {
-      this.gptRefreshAds(
-        Object.keys(
-          this.getRefreshableSlots(...slots),
-        ),
-      );
+      loadPromise.then(() => {
+        this.gptRefreshAds(
+          Object.keys(
+            this.getRefreshableSlots(...slots),
+          ),
+        );
+      });
     }
   },
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -373,17 +373,25 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
     }, slots);
   },
   refresh: function refresh() {
+    var _this6 = this;
+
+    for (var _len4 = arguments.length, slots = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
+      slots[_key4] = arguments[_key4];
+    }
+
     if (loadPromise === null) {
       this.load();
     } else {
-      this.gptRefreshAds(Object.keys(this.getRefreshableSlots.apply(this, arguments)));
+      loadPromise.then(function () {
+        _this6.gptRefreshAds(Object.keys(_this6.getRefreshableSlots.apply(_this6, slots)));
+      });
     }
   },
   gptRefreshAds: function gptRefreshAds(slots) {
-    var _this6 = this;
+    var _this7 = this;
 
     return this.getGoogletag().then(function (googletag) {
-      _this6.configureOptions(googletag);
+      _this7.configureOptions(googletag);
 
       googletag.cmd.push(function () {
         var pubadsService = googletag.pubads();
@@ -394,17 +402,17 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
     });
   },
   reload: function reload() {
-    var _this7 = this;
+    var _this8 = this;
 
     return this.destroyGPTSlots.apply(this, arguments).then(function () {
-      return _this7.load();
+      return _this8.load();
     });
   },
   destroyGPTSlots: function destroyGPTSlots() {
-    var _this8 = this;
+    var _this9 = this;
 
-    for (var _len4 = arguments.length, slotsToDestroy = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
-      slotsToDestroy[_key4] = arguments[_key4];
+    for (var _len5 = arguments.length, slotsToDestroy = new Array(_len5), _key5 = 0; _key5 < _len5; _key5++) {
+      slotsToDestroy[_key5] = arguments[_key5];
     }
 
     if (slotsToDestroy.length === 0) {
@@ -421,7 +429,7 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
         slots.push(slot);
       }
 
-      _this8.getGoogletag().then(function (googletag) {
+      _this9.getGoogletag().then(function (googletag) {
         googletag.cmd.push(function () {
           if (managerAlreadyInitialized === true) {
             if (slotsToDestroy.length > 0) {
@@ -444,7 +452,7 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
     });
   },
   registerSlot: function registerSlot(_ref) {
-    var _this9 = this;
+    var _this10 = this;
 
     var slotId = _ref.slotId,
         dfpNetworkId = _ref.dfpNetworkId,
@@ -483,7 +491,7 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
                 gptSlot = slot.gptSlot;
 
             if (loading === false && !gptSlot) {
-              _this9.load(slotId);
+              _this10.load(slotId);
             }
           }
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dfp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dfp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "homepage": "https://github.com/jaanauati/react-dfp/",
   "author": {
     "name": "Jonatan Alexis Anauati",


### PR DESCRIPTION
Hello!

This bug was a doozy to find, but I think this is the code required to fix it.

If there was a pending (un-resolved) load promise with defineSlot commands sitting waiting to be added to the gpt command queue and refresh was called, refresh would run too soon, calling refresh before the slots were defined. By linking the refresh to the loadPromise, we guarantee that slots that are sitting in the load queue are defined before refresh is called.

This is my first contribution to this library and there's not a formal contributing instructions so please let me know if there's anything else you need from me.