### PR TITLE
issue-157-autoReload-using-original-values

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -104,6 +104,10 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
 
   setTargetingArguments(data) {
     Object.assign(globalTargetingArguments, data);
+    const availableKeys = Object.keys(registeredSlots);
+    availableKeys.forEach((slotId) => {
+      registeredSlots[slotId].targetingArguments = data;
+    });
     if (managerAlreadyInitialized === true) {
       this.getGoogletag().then((googletag) => {
         googletag.cmd.push(() => {
@@ -354,9 +358,8 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
       this.configureOptions(googletag);
       googletag.cmd.push(() => {
         const pubadsService = googletag.pubads();
-        pubadsService.refresh(
-          slots.map(slotId => registeredSlots[slotId].gptSlot),
-        );
+        const slotsToRefreshArray = slots.map(slotId => registeredSlots[slotId].slotId);
+        pubadsService.refresh(slotsToRefreshArray);
       });
     });
   },

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -104,6 +104,10 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
   },
   setTargetingArguments: function setTargetingArguments(data) {
     Object.assign(globalTargetingArguments, data);
+    var availableKeys = Object.keys(registeredSlots);
+    availableKeys.forEach(function (slotId) {
+      registeredSlots[slotId].targetingArguments = data;
+    });
 
     if (managerAlreadyInitialized === true) {
       this.getGoogletag().then(function (googletag) {
@@ -398,9 +402,10 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
 
       googletag.cmd.push(function () {
         var pubadsService = googletag.pubads();
-        pubadsService.refresh(slots.map(function (slotId) {
-          return registeredSlots[slotId].gptSlot;
-        }));
+        var slotsToRefreshArray = slots.map(function (slotId) {
+          return registeredSlots[slotId].slotId;
+        });
+        pubadsService.refresh(slotsToRefreshArray);
       });
     });
   },


### PR DESCRIPTION
Related to issue #157

The targeting values were set correctly, but not updated correctly for client side rendering, only worked with a full page refresh.

The `registeredSlots` were sent on refresh with the original values rather than the new targeting values.

Also, the DFPManager.refresh was refreshing using `registeredSlots[slotId].gptSlot` rather than `registeredSlots[slotId].slotId`

@jaanauati could you let me know if you're happy for this to go ahead? Thanks!